### PR TITLE
feat: NPC 기능 통합(생성, 이동)

### DIFF
--- a/Assets/GroupNPCController.cs
+++ b/Assets/GroupNPCController.cs
@@ -1,0 +1,145 @@
+using UnityEngine;
+using System.Collections;
+using UnityEngine.Events;
+
+public class GroupNPCController : MonoBehaviour
+{
+    [Header("행동 타입")]
+    public BehaviorType behavior;
+    public enum BehaviorType { Fixed, Moving }
+
+    [Header("오브젝트 풀")]
+    public PoolType poolType;  // 알맞은 풀에 반환하기 위한 태그
+    public enum PoolType { MaleMale, MaleFemale, FemaleMale, FemaleFemale }
+
+    [Header("이동 설정")]
+    public float moveSpeed = 3f;
+
+    [Header("참조")]
+    public GameObject questionMarkBubble; // 물음표 말풍선 오브젝트
+
+    [Header("충돌 이벤트")]
+    public UnityEvent onPlayerCollision;  // Inspector에서 이벤트 연결 가능
+
+    // 내부 변수
+    private Animator[] animators;
+    private Vector2 moveDirection = Vector2.zero;
+    private bool isVisible = false;
+    private bool isPaused = false;
+    private string PoolTag => poolType.ToString();
+
+    void Awake()
+    {
+        animators = GetComponentsInChildren<Animator>();
+    }
+
+    void OnEnable()
+    {
+        // 오브젝트 풀에서 재사용될 때마다 상태를 초기화합니다.
+        isVisible = false;
+        isPaused = false;
+        moveDirection = Vector2.zero;
+        if (questionMarkBubble != null)
+        {
+            questionMarkBubble.SetActive(false);
+        }
+    }
+
+    void Update()
+    {
+        if (!isVisible || isPaused)
+        {
+            moveDirection = Vector2.zero;
+            UpdateAnimators();
+            if (!isVisible) // 보이지 않을 경우에는 맵 스크롤에 의해 내려가야 함
+            {
+                transform.Translate(GameManager.currentScrollSpeed * Time.deltaTime * Vector2.down);
+            }
+            return;
+        }
+
+        // 1. 행동 로직 실행
+        switch (behavior)
+        {
+            case BehaviorType.Fixed:
+                RunFixedLogic();
+                break;
+            case BehaviorType.Moving:
+                RunMovingLogic();
+                break;
+        }
+
+        // 2. 실제 이동 처리
+        float currentSpeed = (behavior == BehaviorType.Moving) ? moveSpeed : 0;
+        transform.Translate((moveDirection * currentSpeed + Vector2.down * GameManager.currentScrollSpeed) * Time.deltaTime);
+
+        // 3. 애니메이터 업데이트
+        UpdateAnimators();
+    }
+
+    private void OnBecameVisible()
+    {
+        isVisible = true;
+    }
+
+    void OnBecameInvisible()
+    {
+        isVisible = false;
+        ObjectPooler.Instance.ReturnToPool(gameObject, PoolTag);
+    }
+
+    private void RunFixedLogic()
+    {
+        // 고정
+    }
+
+    private void RunMovingLogic()
+    {
+        // 이동 방향 설정 (아래쪽)
+        moveDirection = Vector2.down;
+    }
+
+    private void UpdateAnimators()
+    {
+        bool isMoving = moveDirection != Vector2.zero;
+
+        foreach (Animator anim in animators)
+        {
+            anim.SetBool("isWalking", isMoving);
+            if (isMoving)
+            {
+                anim.SetFloat("moveX", moveDirection.x);
+                anim.SetFloat("moveY", moveDirection.y);
+            }
+        }
+    }
+
+
+        public void ShowQuestionMark()
+    {
+        if (questionMarkBubble != null)
+        {
+            StartCoroutine(ShowBubbleCoroutine());
+        }
+    }
+
+    private IEnumerator ShowBubbleCoroutine()
+    {
+        questionMarkBubble.SetActive(true);
+        yield return new WaitForSeconds(1.5f);
+        questionMarkBubble.SetActive(false);
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            // 물음표 표시
+            ShowQuestionMark();
+
+            // 이벤트 발생
+            onPlayerCollision?.Invoke();
+        }
+    }
+}
+

--- a/Assets/GroupNPCController.cs
+++ b/Assets/GroupNPCController.cs
@@ -21,7 +21,10 @@ public class GroupNPCController : MonoBehaviour
     [Header("충돌 이벤트")]
     public UnityEvent onPlayerCollision;  // Inspector에서 이벤트 연결 가능
 
-    // 내부 변수
+    [Header("생성된 열")]
+    public float ColumnSpawnedIn; // 무슨 열에서 생성되었는지 저장
+
+    // --- 내부 변수 ---
     private Animator[] animators;
     private Vector2 moveDirection = Vector2.zero;
     private bool isVisible = false;
@@ -85,6 +88,7 @@ public class GroupNPCController : MonoBehaviour
     void OnBecameInvisible()
     {
         isVisible = false;
+        NPCSpawner.Instance.RemoveSpawnRestriction(ColumnSpawnedIn);
         ObjectPooler.Instance.ReturnToPool(gameObject, PoolTag);
     }
 

--- a/Assets/GroupNPCController.cs
+++ b/Assets/GroupNPCController.cs
@@ -26,6 +26,7 @@ public class GroupNPCController : MonoBehaviour
 
     // --- 내부 변수 ---
     private Animator[] animators;
+    private Rigidbody2D rb;
     private Vector2 moveDirection = Vector2.zero;
     private bool isVisible = false;
     private bool isPaused = false;
@@ -34,6 +35,7 @@ public class GroupNPCController : MonoBehaviour
     void Awake()
     {
         animators = GetComponentsInChildren<Animator>();
+        rb = GetComponent<Rigidbody2D>();
     }
 
     void OnEnable()
@@ -48,7 +50,7 @@ public class GroupNPCController : MonoBehaviour
         }
     }
 
-    void Update()
+    void FixedUpdate()
     {
         if (!isVisible || isPaused)
         {
@@ -56,7 +58,8 @@ public class GroupNPCController : MonoBehaviour
             UpdateAnimators();
             if (!isVisible) // 보이지 않을 경우에는 맵 스크롤에 의해 내려가야 함
             {
-                transform.Translate(GameManager.currentScrollSpeed * Time.deltaTime * Vector2.down);
+                Vector3 downScroll = GameManager.currentScrollSpeed * Time.fixedDeltaTime * Vector2.down;
+                rb.MovePosition(transform.position + downScroll);
             }
             return;
         }
@@ -74,7 +77,8 @@ public class GroupNPCController : MonoBehaviour
 
         // 2. 실제 이동 처리
         float currentSpeed = (behavior == BehaviorType.Moving) ? moveSpeed : 0;
-        transform.Translate((moveDirection * currentSpeed + Vector2.down * GameManager.currentScrollSpeed) * Time.deltaTime);
+        Vector3 displacement = (moveDirection * currentSpeed + Vector2.down * GameManager.currentScrollSpeed) * Time.fixedDeltaTime;
+        rb.MovePosition(transform.position + displacement);
 
         // 3. 애니메이터 업데이트
         UpdateAnimators();

--- a/Assets/GroupNPCController.cs
+++ b/Assets/GroupNPCController.cs
@@ -123,7 +123,7 @@ public class GroupNPCController : MonoBehaviour
     }
 
 
-        public void ShowQuestionMark()
+    public void ShowQuestionMark()
     {
         if (questionMarkBubble != null)
         {

--- a/Assets/GroupNPCController.cs.meta
+++ b/Assets/GroupNPCController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3b6f44eb331164249b95062b730c7fb1

--- a/Assets/NPCController.cs
+++ b/Assets/NPCController.cs
@@ -27,6 +27,9 @@ public class NPCController : MonoBehaviour
     [Header("충돌 이벤트")]
     public UnityEvent onPlayerCollision;  // Inspector에서 이벤트 연결 가능
 
+    [Header("생성된 열")]
+    public float ColumnSpawnedIn; // 무슨 열에서 생성되었는지 저장
+
     // --- 내부 변수 ---
     private Animator anim;
     private Transform player;
@@ -103,6 +106,7 @@ public class NPCController : MonoBehaviour
     void OnBecameInvisible()
     {
         isVisible = false;
+        NPCSpawner.Instance.RemoveSpawnRestriction(ColumnSpawnedIn);
         ObjectPooler.Instance.ReturnToPool(gameObject, PoolTag);
     }
 

--- a/Assets/NPCController.cs
+++ b/Assets/NPCController.cs
@@ -54,7 +54,7 @@ public class NPCController : MonoBehaviour
 
     void Update()
     {
-        if (!isVisible || isPaused)
+        if (/*!isVisible ||*/ isPaused)
         {
             SetMoveDirection(Vector2.zero);
             UpdateAnimator();
@@ -73,8 +73,8 @@ public class NPCController : MonoBehaviour
         }
 
         // 2. 실제 이동 처리
-        float currentSpeed = (behavior == BehaviorType.Chaser) ? moveSpeed : mapScrollSpeed;
-        transform.Translate(moveDirection * currentSpeed * Time.deltaTime);
+        float currentSpeed = (behavior == BehaviorType.Chaser) ? moveSpeed : 0;
+        transform.Translate((moveDirection * currentSpeed + Vector2.down * GameManager.currentScrollSpeed) * Time.deltaTime);
 
         // 3. 애니메이터 업데이트
         UpdateAnimator();
@@ -98,8 +98,8 @@ public class NPCController : MonoBehaviour
 
     private void RunFixedLogic()
     {
-        // 고정형 NPC는 항상 화면 아래 방향으로 이동하도록 설정합니다.
-        SetMoveDirection(Vector2.down);
+        // 고정형은 움직이지 않음
+        // SetMoveDirection(Vector2.down);
     }
 
     private void RunChaserLogic()
@@ -133,9 +133,9 @@ public class NPCController : MonoBehaviour
                 }
             }
         }
-        else // 아직 활성화되지 않았다면 고정형처럼 아래로 내려가기만 함
+        else // 추적/배회가 아닐 때는 움직이지 않음
         {
-            SetMoveDirection(Vector2.down);
+            // SetMoveDirection(Vector2.down);
         }
     }
 

--- a/Assets/NPCController.cs
+++ b/Assets/NPCController.cs
@@ -54,12 +54,17 @@ public class NPCController : MonoBehaviour
 
     void Update()
     {
-        if (/*!isVisible ||*/ isPaused)
+        if (!isVisible || isPaused)
         {
             SetMoveDirection(Vector2.zero);
             UpdateAnimator();
+            if (!isVisible) // 보이지 않을 경우에는 맵 스크롤에 의해 내려가는 코드를 포함
+            {
+                transform.Translate(GameManager.currentScrollSpeed * Time.deltaTime * Vector2.down);
+            }
             return;
         }
+
 
         // 1. 행동 로직 실행
         switch (behavior)

--- a/Assets/NPCController.cs
+++ b/Assets/NPCController.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections;
+using UnityEngine.Events;
 
 public class NPCController : MonoBehaviour
 {
@@ -18,6 +19,9 @@ public class NPCController : MonoBehaviour
 
     [Header("참조")]
     public GameObject questionMarkBubble; // 물음표 말풍선 오브젝트
+
+    [Header("충돌 이벤트")]
+    public UnityEvent onPlayerCollision;  // Inspector에서 이벤트 연결 가능
 
     // --- 내부 변수 ---
     private Animator anim;
@@ -67,7 +71,7 @@ public class NPCController : MonoBehaviour
                 RunChaserLogic();
                 break;
         }
-        
+
         // 2. 실제 이동 처리
         float currentSpeed = (behavior == BehaviorType.Chaser) ? moveSpeed : mapScrollSpeed;
         transform.Translate(moveDirection * currentSpeed * Time.deltaTime);
@@ -134,7 +138,7 @@ public class NPCController : MonoBehaviour
             SetMoveDirection(Vector2.down);
         }
     }
-    
+
     private void UpdateAnimator()
     {
         bool isMoving = moveDirection != Vector2.zero;
@@ -146,12 +150,12 @@ public class NPCController : MonoBehaviour
             anim.SetFloat("moveY", moveDirection.y);
         }
     }
-    
+
     private void SetMoveDirection(Vector2 direction)
     {
         moveDirection = direction.normalized;
     }
-    
+
     public void ShowQuestionMark()
     {
         if (questionMarkBubble != null)
@@ -165,5 +169,17 @@ public class NPCController : MonoBehaviour
         questionMarkBubble.SetActive(true);
         yield return new WaitForSeconds(1.5f);
         questionMarkBubble.SetActive(false);
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            // 물음표 표시
+            ShowQuestionMark();
+
+            // 이벤트 발생
+            onPlayerCollision?.Invoke();
+        }
     }
 }

--- a/Assets/NPCController.cs
+++ b/Assets/NPCController.cs
@@ -10,11 +10,8 @@ public class NPCController : MonoBehaviour
     public enum BehaviorType { Fixed, Chaser }
 
     [Header("오브젝트 풀")]
-    public PoolType poolType;
+    public PoolType poolType; // 알맞은 풀에 반환하기 위한 태그
     public enum PoolType { Male, Female }
-
-    [Header("맵 스크롤 속도")]
-    public float mapScrollSpeed = 3f; // 플레이어의 전진(맵 스크롤) 속도와 맞춰야 합니다.
 
     [Header("추적자(Chaser) 설정")]
     public float moveSpeed = 2f;         // 이동 속도
@@ -66,7 +63,7 @@ public class NPCController : MonoBehaviour
         {
             SetMoveDirection(Vector2.zero);
             UpdateAnimator();
-            if (!isVisible) // 보이지 않을 경우에는 맵 스크롤에 의해 내려가는 코드를 포함
+            if (!isVisible) // 보이지 않을 경우에는 맵 스크롤에 의해 내려가야 함
             {
                 transform.Translate(GameManager.currentScrollSpeed * Time.deltaTime * Vector2.down);
             }
@@ -123,7 +120,7 @@ public class NPCController : MonoBehaviour
         {
             float distanceToPlayer = Vector2.Distance(transform.position, player.position);
             bool isPlayerInSight = (distanceToPlayer < detectionRadius) && (player.position.y < transform.position.y);
-
+            
             if (isPlayerInSight)
             {
                 Vector2 directionToPlayer = (player.position - transform.position).normalized;
@@ -136,7 +133,7 @@ public class NPCController : MonoBehaviour
                 {
                     if (Random.value < 0.8f)
                     {
-                        Vector2 randomDirection = new Vector2(Random.Range(-1f, 1f), Random.Range(-1f, 1f)).normalized;
+                        Vector2 randomDirection = Random.insideUnitSphere.normalized;
                         SetMoveDirection(randomDirection);
                     }
                     else

--- a/Assets/NPCController.cs
+++ b/Assets/NPCController.cs
@@ -30,6 +30,7 @@ public class NPCController : MonoBehaviour
     // --- 내부 변수 ---
     private Animator anim;
     private Transform player;
+    private Rigidbody2D rb;
     private Vector2 moveDirection = Vector2.zero;
     private bool isVisible = false;
     private float randomMoveTimer;
@@ -41,6 +42,7 @@ public class NPCController : MonoBehaviour
     {
         anim = GetComponentInChildren<Animator>();
         player = GameObject.FindGameObjectWithTag("Player").transform;
+        rb = GetComponent<Rigidbody2D>();
     }
 
     void OnEnable()
@@ -57,7 +59,7 @@ public class NPCController : MonoBehaviour
         }
     }
 
-    void Update()
+    void FixedUpdate()
     {
         if (!isVisible || isPaused)
         {
@@ -65,7 +67,8 @@ public class NPCController : MonoBehaviour
             UpdateAnimator();
             if (!isVisible) // 보이지 않을 경우에는 맵 스크롤에 의해 내려가야 함
             {
-                transform.Translate(GameManager.currentScrollSpeed * Time.deltaTime * Vector2.down);
+                Vector3 downScroll = GameManager.currentScrollSpeed * Time.fixedDeltaTime * Vector2.down;
+                rb.MovePosition(transform.position + downScroll);
             }
             return;
         }
@@ -84,7 +87,8 @@ public class NPCController : MonoBehaviour
 
         // 2. 실제 이동 처리
         float currentSpeed = (behavior == BehaviorType.Chaser) ? moveSpeed : 0;
-        transform.Translate((moveDirection * currentSpeed + Vector2.down * GameManager.currentScrollSpeed) * Time.deltaTime);
+        Vector3 positionChange = (moveDirection * currentSpeed + Vector2.down * GameManager.currentScrollSpeed) * Time.fixedDeltaTime;
+        rb.MovePosition(transform.position + positionChange);
 
         // 3. 애니메이터 업데이트
         UpdateAnimator();
@@ -128,7 +132,7 @@ public class NPCController : MonoBehaviour
             }
             else
             {
-                randomMoveTimer -= Time.deltaTime;
+                randomMoveTimer -= Time.fixedDeltaTime;
                 if (randomMoveTimer <= 0)
                 {
                     if (Random.value < 0.8f)

--- a/Assets/NPCController.cs
+++ b/Assets/NPCController.cs
@@ -137,7 +137,7 @@ public class NPCController : MonoBehaviour
                 {
                     if (Random.value < 0.8f)
                     {
-                        Vector2 randomDirection = Random.insideUnitSphere.normalized;
+                        Vector2 randomDirection = Random.insideUnitCircle.normalized;
                         SetMoveDirection(randomDirection);
                     }
                     else

--- a/Assets/NPCController.cs
+++ b/Assets/NPCController.cs
@@ -9,6 +9,10 @@ public class NPCController : MonoBehaviour
     public BehaviorType behavior;
     public enum BehaviorType { Fixed, Chaser }
 
+    [Header("오브젝트 풀")]
+    public PoolType poolType;
+    public enum PoolType { Male, Female }
+
     [Header("맵 스크롤 속도")]
     public float mapScrollSpeed = 3f; // 플레이어의 전진(맵 스크롤) 속도와 맞춰야 합니다.
 
@@ -31,6 +35,7 @@ public class NPCController : MonoBehaviour
     private float randomMoveTimer;
     private bool isPaused = false;
     private bool isChaserLogicActivated = false; // Chaser 로직 활성화 스위치
+    private string PoolTag => poolType.ToString();
 
     void Awake()
     {
@@ -98,7 +103,7 @@ public class NPCController : MonoBehaviour
     void OnBecameInvisible()
     {
         isVisible = false;
-        gameObject.SetActive(false); // 오브젝트 풀로 반환
+        ObjectPooler.Instance.ReturnToPool(gameObject, PoolTag);
     }
 
     private void RunFixedLogic()

--- a/Assets/NPCSpawner.cs
+++ b/Assets/NPCSpawner.cs
@@ -7,18 +7,23 @@ public class NPCSpawner : MonoBehaviour
 
     [Header("스폰 설정")]
     public Transform gridStartPosition;
+    public Transform background;
     public int columns = 3;
     public int rows = 5;
-    public float zoneWidth = 10f;
-    public float zoneHeight = 5f;
     public float waveInterval = 10f;
     public int spawnCountPerWave = 4;
 
+    private float zoneWidth = 10f;
+    private float zoneHeight = 5f;
     private List<Vector2> calculatedSpawnZones;
     private string[] genderTags = { "Male", "Female" };
 
     void Awake()
     {
+        // 스폰 존 면적 자동 계산 
+        zoneHeight = background.localScale.y / rows;
+        zoneWidth = background.localScale.x / columns;
+
         // 스폰 존 위치 자동 계산
         calculatedSpawnZones = new List<Vector2>();
         for (int r = 0; r < rows; r++)
@@ -26,7 +31,7 @@ public class NPCSpawner : MonoBehaviour
             for (int c = 0; c < columns; c++)
             {
                 float x = gridStartPosition.position.x + (c * zoneWidth);
-                float y = gridStartPosition.position.y - (r * zoneHeight);
+                float y = gridStartPosition.position.y + (r * zoneHeight);
                 calculatedSpawnZones.Add(new Vector2(x, y));
             }
         }

--- a/Assets/NPCSpawner.cs
+++ b/Assets/NPCSpawner.cs
@@ -94,7 +94,7 @@ public class NPCSpawner : MonoBehaviour
             }
 
             // 위치 랜덤 설정
-            Vector2 spawnPos = zoneCenter + new Vector2(Random.Range(-zoneWidth/2 + zonePadding, zoneWidth/2 - zonePadding), Random.Range(-zoneHeight/2 + zonePadding, zoneHeight - zonePadding));
+            Vector2 spawnPos = zoneCenter + new Vector2(Random.Range(-zoneWidth/2 + zonePadding, zoneWidth/2 - zonePadding), Random.Range(-zoneHeight/2 + zonePadding, zoneHeight/2 - zonePadding));
 
             // 풀에서 NPC 스폰
             GameObject npc = objectPooler.SpawnFromPool(npcTag, spawnPos, Quaternion.identity);

--- a/Assets/NPCSpawner.cs
+++ b/Assets/NPCSpawner.cs
@@ -102,7 +102,7 @@ public class NPCSpawner : MonoBehaviour
             // 행동 타입 랜덤 결정 후 코드로 설정
             if (isSingleSpawning)
             {
-                if (Random.value > chasingNPCChance) // 추적형 생성
+                if (Random.value > chasingNPCChance) // 고정형 생성
                 {
                     // 수직이동형 스폰 금지 열 등록
                     movingGroupsRestrictedColumns.Add(zoneCenter.x);
@@ -112,7 +112,7 @@ public class NPCSpawner : MonoBehaviour
                     npcController.behavior = NPCController.BehaviorType.Fixed;
                     npcController.ColumnSpawnedIn = zoneCenter.x;
                 }
-                else // 고정형 생성
+                else // 추적형 생성
                 {
                     npc.GetComponent<NPCController>().behavior = NPCController.BehaviorType.Chaser;
                 }

--- a/Assets/NPCSpawner.cs
+++ b/Assets/NPCSpawner.cs
@@ -10,13 +10,14 @@ public class NPCSpawner : MonoBehaviour
     public Transform background;
     public int columns = 3;
     public int rows = 5;
-    public float waveInterval = 10f;
+    public float waveInterval = 60f;
     public int spawnCountPerWave = 4;
 
     private float zoneWidth = 10f;
     private float zoneHeight = 5f;
     private List<Vector2> calculatedSpawnZones;
     private string[] genderTags = { "Male", "Female" };
+    private string[] groupTags = { "MaleMale", "MaleFemale", "FemaleMale", "FemaleFemale" };
 
     void Awake()
     {
@@ -61,23 +62,47 @@ public class NPCSpawner : MonoBehaviour
         // 2. 선택된 각 위치에 NPC 스폰 및 행동 설정
         foreach (Vector2 zoneCenter in selectedZones)
         {
-            // 성별 랜덤 결정
-            string genderTag = genderTags[Random.Range(0, genderTags.Length)];
-            
+            string npcTag;
+            bool isSingleSpawning = Random.value > 0.5f;
+
+            if (isSingleSpawning)
+            {
+                // 성별 랜덤 결정
+                npcTag = genderTags[Random.Range(0, genderTags.Length)];
+            }
+            else
+            {
+                // 성별 조합 랜덤 결정
+                npcTag = groupTags[Random.Range(0, groupTags.Length)];
+            }
+
             // 위치 랜덤 설정
             Vector2 spawnPos = zoneCenter + new Vector2(Random.Range(-1f, 1f), Random.Range(-1f, 1f));
             
             // 풀에서 NPC 스폰
-            GameObject npc = objectPooler.SpawnFromPool(genderTag, spawnPos, Quaternion.identity);
-
+            GameObject npc = objectPooler.SpawnFromPool(npcTag, spawnPos, Quaternion.identity);
             // 행동 타입 랜덤 결정 후 코드로 설정
-            if (Random.value > 0.5f)
+            if (isSingleSpawning)
             {
-                npc.GetComponent<NPCController>().behavior = NPCController.BehaviorType.Fixed;
+                if (Random.value > 0.5f)
+                {
+                    npc.GetComponent<NPCController>().behavior = NPCController.BehaviorType.Fixed;
+                }
+                else
+                {
+                    npc.GetComponent<NPCController>().behavior = NPCController.BehaviorType.Chaser;
+                }
             }
             else
             {
-                npc.GetComponent<NPCController>().behavior = NPCController.BehaviorType.Chaser;
+                if (Random.value > 0.5f)
+                {
+                    npc.GetComponent<GroupNPCController>().behavior = GroupNPCController.BehaviorType.Fixed;
+                }
+                else
+                {
+                    npc.GetComponent<GroupNPCController>().behavior = GroupNPCController.BehaviorType.Moving;
+                }
             }
         }
     }

--- a/Assets/NPCSpawner.cs
+++ b/Assets/NPCSpawner.cs
@@ -145,10 +145,14 @@ public class NPCSpawner : MonoBehaviour
     }
 
 
-    // 스폰 구역 그리는 테스트용 코드
-    // (가끔 Game 종료 시 여기서 에러 뜨는데 무시해도 될 듯)
+    // 그냥 스폰 구역 그리는 테스트용 코드
     void OnDrawGizmos()
     {
+        if (calculatedSpawnZones == null)
+        {
+            return;
+        }
+    
         foreach (Vector2 zone in calculatedSpawnZones)
         {
             Gizmos.color = Color.green;

--- a/Assets/NPCSpawner.cs
+++ b/Assets/NPCSpawner.cs
@@ -29,6 +29,7 @@ public class NPCSpawner : MonoBehaviour
     private string[] genderTags = { "Male", "Female" };
     private string[] groupTags = { "MaleMale", "MaleFemale", "FemaleMale", "FemaleFemale" };
     private List<float> movingGroupsRestrictedColumns; // 수직이동형 스폰 금지 열 저장
+    private float zonePadding = 0.5f; // 생성 시 NPC끼리 겹치지 않기 위한 여분 공간 
 
     void Awake()
     {
@@ -93,7 +94,7 @@ public class NPCSpawner : MonoBehaviour
             }
 
             // 위치 랜덤 설정
-            Vector2 spawnPos = zoneCenter + new Vector2(Random.Range(-1f, 1f), Random.Range(-1f, 1f));
+            Vector2 spawnPos = zoneCenter + new Vector2(Random.Range(-zoneWidth/2 + zonePadding, zoneWidth/2 - zonePadding), Random.Range(-zoneHeight/2 + zonePadding, zoneHeight - zonePadding));
 
             // 풀에서 NPC 스폰
             GameObject npc = objectPooler.SpawnFromPool(npcTag, spawnPos, Quaternion.identity);
@@ -147,5 +148,30 @@ public class NPCSpawner : MonoBehaviour
     public void RemoveSpawnRestriction(float column)
     {
         movingGroupsRestrictedColumns.Remove(column);
+    }
+
+
+    // 스폰 구역 그리는 테스트용 코드
+    // (가끔 Game 종료 시 여기서 에러 뜨는데 무시해도 될 듯)
+    void OnDrawGizmos()
+    {
+        foreach (Vector2 zone in calculatedSpawnZones)
+        {
+            Gizmos.color = Color.green;
+            // 스폰 구역 중심
+            Gizmos.DrawSphere(zone, 0.1f);
+
+            // 스폰 구역 둘레
+            Vector2[] points = {
+                zone + new Vector2(-zoneWidth / 2 + zonePadding, zoneHeight / 2 - zonePadding),
+                zone + new Vector2(zoneWidth / 2 - zonePadding, zoneHeight / 2 - zonePadding),
+                zone + new Vector2(zoneWidth / 2 - zonePadding, -zoneHeight / 2 + zonePadding),
+                zone + new Vector2(-zoneWidth / 2 + zonePadding, -zoneHeight / 2 + zonePadding)
+            };
+            Gizmos.DrawLine(points[0], points[1]);
+            Gizmos.DrawLine(points[1], points[2]);
+            Gizmos.DrawLine(points[2], points[3]);
+            Gizmos.DrawLine(points[3], points[0]);
+        }
     }
 }

--- a/Assets/NPCSpawner.cs
+++ b/Assets/NPCSpawner.cs
@@ -102,10 +102,12 @@ public class NPCSpawner : MonoBehaviour
             // 행동 타입 랜덤 결정 후 코드로 설정
             if (isSingleSpawning)
             {
-                if (Random.value > chasingNPCChance)
+                if (Random.value > chasingNPCChance) // 추적형 생성
                 {
                     // 수직이동형 스폰 금지 열 등록
                     movingGroupsRestrictedColumns.Add(zoneCenter.x);
+
+                    // NPC 초기화
                     NPCController npcController = npc.GetComponent<NPCController>();
                     npcController.behavior = NPCController.BehaviorType.Fixed;
                     npcController.ColumnSpawnedIn = zoneCenter.x;
@@ -117,28 +119,20 @@ public class NPCSpawner : MonoBehaviour
             }
             else // 단체 NPC 생성
             {
-                if (Random.value > movingGroupNPCChance)
+                if (Random.value < movingGroupNPCChance
+                    && !movingGroupsRestrictedColumns.Contains(zoneCenter.x)) // 수직이동형 생성
+                {
+                    npc.GetComponent<GroupNPCController>().behavior = GroupNPCController.BehaviorType.Moving;
+                }
+                else // 고정형 생성
                 {
                     // 수직이동형 스폰 금지 열 등록
                     movingGroupsRestrictedColumns.Add(zoneCenter.x);
+
+                    // NPC 초기화
                     GroupNPCController groupNpcController = npc.GetComponent<GroupNPCController>();
                     groupNpcController.behavior = GroupNPCController.BehaviorType.Fixed;
                     groupNpcController.ColumnSpawnedIn = zoneCenter.x;
-                }
-                else
-                {
-                    // 수직이동형 스폰 금지 열이 아니면 수직이동형 생성
-                    if (!movingGroupsRestrictedColumns.Contains(zoneCenter.x))
-                    {
-                        npc.GetComponent<GroupNPCController>().behavior = GroupNPCController.BehaviorType.Moving;
-                    }
-                    else // 고정형 생성
-                    {
-                        movingGroupsRestrictedColumns.Add(zoneCenter.x);
-                        GroupNPCController groupNpcController = npc.GetComponent<GroupNPCController>();
-                        groupNpcController.behavior = GroupNPCController.BehaviorType.Fixed;
-                        groupNpcController.ColumnSpawnedIn = zoneCenter.x;
-                    }
                 }
             }
         }

--- a/Assets/NewNPC/NPC_female.prefab
+++ b/Assets/NewNPC/NPC_female.prefab
@@ -191,11 +191,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   behavior: 0
   poolType: 1
-  mapScrollSpeed: 3
   moveSpeed: 2
-  detectionRadius: 5
-  randomMoveInterval: 2
+  detectionRadius: 4
+  randomMoveInterval: 1
   questionMarkBubble: {fileID: 0}
   onPlayerCollision:
     m_PersistentCalls:
       m_Calls: []
+  ColumnSpawnedIn: 0

--- a/Assets/NewNPC/NPC_female.prefab
+++ b/Assets/NewNPC/NPC_female.prefab
@@ -190,7 +190,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   behavior: 0
+  poolType: 1
+  mapScrollSpeed: 3
   moveSpeed: 2
   detectionRadius: 5
   randomMoveInterval: 2
   questionMarkBubble: {fileID: 0}
+  onPlayerCollision:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/NewNPC/NPC_female_female.prefab
+++ b/Assets/NewNPC/NPC_female_female.prefab
@@ -1,0 +1,181 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1892038888814880474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5645457788717700310}
+  - component: {fileID: 1478955725787316215}
+  m_Layer: 0
+  m_Name: NPC_female_female
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5645457788717700310
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5612908125679610398}
+  - {fileID: 1572459273147242110}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1478955725787316215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b6f44eb331164249b95062b730c7fb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  behavior: 0
+  poolType: 3
+  moveSpeed: 3
+  questionMarkBubble: {fileID: 0}
+  onPlayerCollision:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1001 &3391409238299072403
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5645457788717700310}
+    m_Modifications:
+    - target: {fileID: 2756065083760134691, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_Name
+      value: NPC_female
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 2348996504197374676, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+--- !u!4 &5612908125679610398 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+  m_PrefabInstance: {fileID: 3391409238299072403}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8586048818510294003
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5645457788717700310}
+    m_Modifications:
+    - target: {fileID: 2756065083760134691, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_Name
+      value: NPC_female
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 2348996504197374676, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+--- !u!4 &1572459273147242110 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+  m_PrefabInstance: {fileID: 8586048818510294003}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/NewNPC/NPC_female_female.prefab
+++ b/Assets/NewNPC/NPC_female_female.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 1478955725787316215}
   - component: {fileID: 9013921380490695875}
   - component: {fileID: -2921006059170681815}
+  - component: {fileID: 8859096878000813415}
   m_Layer: 0
   m_Name: NPC_female_female
   m_TagString: Untagged
@@ -138,6 +139,52 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!61 &8859096878000813415
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 0.75, y: 0.38}
+  m_EdgeRadius: 0
 --- !u!1001 &3391409238299072403
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/NewNPC/NPC_female_female.prefab
+++ b/Assets/NewNPC/NPC_female_female.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 5645457788717700310}
   - component: {fileID: 1478955725787316215}
   - component: {fileID: 9013921380490695875}
+  - component: {fileID: -2921006059170681815}
   m_Layer: 0
   m_Name: NPC_female_female
   m_TagString: Untagged
@@ -54,6 +55,7 @@ MonoBehaviour:
   onPlayerCollision:
     m_PersistentCalls:
       m_Calls: []
+  ColumnSpawnedIn: 0
 --- !u!212 &9013921380490695875
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -109,6 +111,33 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!50 &-2921006059170681815
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1001 &3391409238299072403
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/NewNPC/NPC_female_female.prefab
+++ b/Assets/NewNPC/NPC_female_female.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5645457788717700310}
   - component: {fileID: 1478955725787316215}
+  - component: {fileID: 9013921380490695875}
   m_Layer: 0
   m_Name: NPC_female_female
   m_TagString: Untagged
@@ -53,6 +54,61 @@ MonoBehaviour:
   onPlayerCollision:
     m_PersistentCalls:
       m_Calls: []
+--- !u!212 &9013921380490695875
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1001 &3391409238299072403
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/NewNPC/NPC_female_female.prefab.meta
+++ b/Assets/NewNPC/NPC_female_female.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c33488e7e4699014a8ecf667a9263fa1
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NewNPC/NPC_female_male.prefab
+++ b/Assets/NewNPC/NPC_female_male.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5645457788717700310}
   - component: {fileID: -4520903101134994490}
+  - component: {fileID: 5946089748351958796}
   m_Layer: 0
   m_Name: NPC_female_male
   m_TagString: Untagged
@@ -53,6 +54,61 @@ MonoBehaviour:
   onPlayerCollision:
     m_PersistentCalls:
       m_Calls: []
+--- !u!212 &5946089748351958796
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1001 &3391409238299072403
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/NewNPC/NPC_female_male.prefab
+++ b/Assets/NewNPC/NPC_female_male.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 5645457788717700310}
   - component: {fileID: -4520903101134994490}
   - component: {fileID: 5946089748351958796}
+  - component: {fileID: 4032784817813130418}
   m_Layer: 0
   m_Name: NPC_female_male
   m_TagString: Untagged
@@ -54,6 +55,7 @@ MonoBehaviour:
   onPlayerCollision:
     m_PersistentCalls:
       m_Calls: []
+  ColumnSpawnedIn: 0
 --- !u!212 &5946089748351958796
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -109,6 +111,33 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!50 &4032784817813130418
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1001 &3391409238299072403
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/NewNPC/NPC_female_male.prefab
+++ b/Assets/NewNPC/NPC_female_male.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: -4520903101134994490}
   - component: {fileID: 5946089748351958796}
   - component: {fileID: 4032784817813130418}
+  - component: {fileID: 1714277418172443068}
   m_Layer: 0
   m_Name: NPC_female_male
   m_TagString: Untagged
@@ -138,6 +139,52 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
+--- !u!61 &1714277418172443068
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 0.75, y: 0.38}
+  m_EdgeRadius: 0
 --- !u!1001 &3391409238299072403
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/NewNPC/NPC_female_male.prefab
+++ b/Assets/NewNPC/NPC_female_male.prefab
@@ -1,0 +1,181 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1892038888814880474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5645457788717700310}
+  - component: {fileID: -4520903101134994490}
+  m_Layer: 0
+  m_Name: NPC_female_male
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5645457788717700310
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5612908125679610398}
+  - {fileID: 1360290038940420861}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-4520903101134994490
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b6f44eb331164249b95062b730c7fb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  behavior: 0
+  poolType: 2
+  moveSpeed: 3
+  questionMarkBubble: {fileID: 0}
+  onPlayerCollision:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1001 &3391409238299072403
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5645457788717700310}
+    m_Modifications:
+    - target: {fileID: 2756065083760134691, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_Name
+      value: NPC_female
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 2348996504197374676, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+--- !u!4 &5612908125679610398 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+  m_PrefabInstance: {fileID: 3391409238299072403}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5275131546862858475
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5645457788717700310}
+    m_Modifications:
+    - target: {fileID: 1187305517395509251, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_Name
+      value: NPC_male
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 2347825708304157716, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+--- !u!4 &1360290038940420861 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+  m_PrefabInstance: {fileID: 5275131546862858475}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/NewNPC/NPC_female_male.prefab.meta
+++ b/Assets/NewNPC/NPC_female_male.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ffec0f956659d4848b6b97b37c20ae0e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NewNPC/NPC_male.prefab
+++ b/Assets/NewNPC/NPC_male.prefab
@@ -191,11 +191,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   behavior: 0
   poolType: 0
-  mapScrollSpeed: 3
   moveSpeed: 2
-  detectionRadius: 5
-  randomMoveInterval: 2
+  detectionRadius: 4
+  randomMoveInterval: 1
   questionMarkBubble: {fileID: 0}
   onPlayerCollision:
     m_PersistentCalls:
       m_Calls: []
+  ColumnSpawnedIn: 0

--- a/Assets/NewNPC/NPC_male.prefab
+++ b/Assets/NewNPC/NPC_male.prefab
@@ -190,7 +190,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   behavior: 0
+  poolType: 0
+  mapScrollSpeed: 3
   moveSpeed: 2
   detectionRadius: 5
   randomMoveInterval: 2
   questionMarkBubble: {fileID: 0}
+  onPlayerCollision:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/NewNPC/NPC_male_female.prefab
+++ b/Assets/NewNPC/NPC_male_female.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: -4217855557611790513}
   - component: {fileID: 7283960713171785130}
   - component: {fileID: -5704741319837140720}
+  - component: {fileID: 5414378327861700720}
   m_Layer: 0
   m_Name: NPC_male_female
   m_TagString: Untagged
@@ -55,6 +56,7 @@ MonoBehaviour:
   onPlayerCollision:
     m_PersistentCalls:
       m_Calls: []
+  ColumnSpawnedIn: 0
 --- !u!61 &7283960713171785130
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -156,6 +158,33 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!50 &5414378327861700720
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1001 &3391409238299072403
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/NewNPC/NPC_male_female.prefab
+++ b/Assets/NewNPC/NPC_male_female.prefab
@@ -10,6 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 5645457788717700310}
   - component: {fileID: -4217855557611790513}
+  - component: {fileID: 7283960713171785130}
+  - component: {fileID: -5704741319837140720}
   m_Layer: 0
   m_Name: NPC_male_female
   m_TagString: Untagged
@@ -53,6 +55,107 @@ MonoBehaviour:
   onPlayerCollision:
     m_PersistentCalls:
       m_Calls: []
+--- !u!61 &7283960713171785130
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 0.75, y: 0.39}
+  m_EdgeRadius: 0
+--- !u!212 &-5704741319837140720
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1001 &3391409238299072403
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/NewNPC/NPC_male_female.prefab
+++ b/Assets/NewNPC/NPC_male_female.prefab
@@ -1,0 +1,181 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1892038888814880474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5645457788717700310}
+  - component: {fileID: -4217855557611790513}
+  m_Layer: 0
+  m_Name: NPC_male_female
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5645457788717700310
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1360290038940420861}
+  - {fileID: 5612908125679610398}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-4217855557611790513
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b6f44eb331164249b95062b730c7fb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  behavior: 0
+  poolType: 1
+  moveSpeed: 3
+  questionMarkBubble: {fileID: 0}
+  onPlayerCollision:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1001 &3391409238299072403
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5645457788717700310}
+    m_Modifications:
+    - target: {fileID: 2756065083760134691, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_Name
+      value: NPC_female
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 2348996504197374676, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+--- !u!4 &5612908125679610398 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7130810680248253837, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
+  m_PrefabInstance: {fileID: 3391409238299072403}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5275131546862858475
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5645457788717700310}
+    m_Modifications:
+    - target: {fileID: 1187305517395509251, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_Name
+      value: NPC_male
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 2347825708304157716, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+--- !u!4 &1360290038940420861 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+  m_PrefabInstance: {fileID: 5275131546862858475}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/NewNPC/NPC_male_female.prefab.meta
+++ b/Assets/NewNPC/NPC_male_female.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e8556af67a023344c826e9aad311747d
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/NewNPC/NPC_male_male.prefab
+++ b/Assets/NewNPC/NPC_male_male.prefab
@@ -1,0 +1,180 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1892038888814880474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5645457788717700310}
+  - component: {fileID: 1490062224698619923}
+  m_Layer: 0
+  m_Name: NPC_male_male
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5645457788717700310
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1360290038940420861}
+  - {fileID: 8655224064032579237}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1490062224698619923
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b6f44eb331164249b95062b730c7fb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  behavior: 0
+  poolType: 0
+  moveSpeed: 3
+  checkRadius: 4
+  forwardCheckDistance: 4
+  checkWidth: 1
+--- !u!1001 &2578373226714326195
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5645457788717700310}
+    m_Modifications:
+    - target: {fileID: 1187305517395509251, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_Name
+      value: NPC_male
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 2347825708304157716, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+--- !u!4 &8655224064032579237 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+  m_PrefabInstance: {fileID: 2578373226714326195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5275131546862858475
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5645457788717700310}
+    m_Modifications:
+    - target: {fileID: 1187305517395509251, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_Name
+      value: NPC_male
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.28
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 2347825708304157716, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+--- !u!4 &1360290038940420861 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6617389446863813142, guid: faff095cfbe5245f3bbb1c01deb08098, type: 3}
+  m_PrefabInstance: {fileID: 5275131546862858475}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/NewNPC/NPC_male_male.prefab
+++ b/Assets/NewNPC/NPC_male_male.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 1490062224698619923}
   - component: {fileID: 3375209874470870332}
   - component: {fileID: -5365573422914450944}
+  - component: {fileID: 3506627684299001654}
   m_Layer: 0
   m_Name: NPC_male_male
   m_TagString: Untagged
@@ -55,6 +56,7 @@ MonoBehaviour:
   onPlayerCollision:
     m_PersistentCalls:
       m_Calls: []
+  ColumnSpawnedIn: 0
 --- !u!61 &3375209874470870332
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -156,6 +158,33 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!50 &3506627684299001654
+Rigidbody2D:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1001 &2578373226714326195
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/NewNPC/NPC_male_male.prefab
+++ b/Assets/NewNPC/NPC_male_male.prefab
@@ -10,6 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 5645457788717700310}
   - component: {fileID: 1490062224698619923}
+  - component: {fileID: 3375209874470870332}
+  - component: {fileID: -5365573422914450944}
   m_Layer: 0
   m_Name: NPC_male_male
   m_TagString: Untagged
@@ -49,9 +51,111 @@ MonoBehaviour:
   behavior: 0
   poolType: 0
   moveSpeed: 3
-  checkRadius: 4
-  forwardCheckDistance: 4
-  checkWidth: 1
+  questionMarkBubble: {fileID: 0}
+  onPlayerCollision:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!61 &3375209874470870332
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 0.75, y: 0.39}
+  m_EdgeRadius: 0
+--- !u!212 &-5365573422914450944
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1892038888814880474}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1001 &2578373226714326195
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/NewNPC/NPC_male_male.prefab.meta
+++ b/Assets/NewNPC/NPC_male_male.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 50f1636e6eb81f14b8e779d709acc2df
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ObjectPooler.cs
+++ b/Assets/ObjectPooler.cs
@@ -37,6 +37,12 @@ public class ObjectPooler : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// 오브젝트 풀에서 오브젝트를 가져오거나 생성합니다.
+    /// </summary>
+    /// <param name="tag">풀의 식별 태그</param>
+    /// <param name="position">생성할 위치</param>
+    /// <param name="rotation">생성할 회전값</param>
     public GameObject SpawnFromPool(string tag, Vector3 position, Quaternion rotation)
     {
         if (!poolDictionary.ContainsKey(tag))
@@ -45,13 +51,54 @@ public class ObjectPooler : MonoBehaviour
             return null;
         }
 
-        GameObject objectToSpawn = poolDictionary[tag].Dequeue();
+        GameObject objectToSpawn;
+        
+        // 풀이 비어있으면 새로운 오브젝트 생성
+        if (poolDictionary[tag].Count == 0)
+        {
+            Pool poolSettings = pools.Find(p => p.tag == tag);
+            objectToSpawn = Instantiate(poolSettings.prefab);
+        }
+        else
+        {
+            // 풀에서 비활성화된 오브젝트 재사용
+            objectToSpawn = poolDictionary[tag].Dequeue();
+        }
+        
+        // 오브젝트 활성화 및 위치/회전 설정
         objectToSpawn.SetActive(true);
         objectToSpawn.transform.position = position;
         objectToSpawn.transform.rotation = rotation;
         
-        poolDictionary[tag].Enqueue(objectToSpawn);
-
         return objectToSpawn;
+    }
+
+    /// <summary>
+    /// 사용이 끝난 오브젝트를 풀로 반환하거나 파괴합니다.
+    /// </summary>
+    /// <param name="obj">반환할 게임오브젝트</param>
+    /// <param name="tag">해당 오브젝트의 풀 태그</param>
+    public void ReturnToPool(GameObject obj, string tag)
+    {
+        // 해당 태그의 풀이 존재하지 않으면 오브젝트 파괴
+        if (!poolDictionary.ContainsKey(tag))
+        {
+            Debug.LogWarning("Pool with tag " + tag + " doesn't exist.");
+            Destroy(obj);
+            return;
+        }
+
+        // 풀의 크기 제한 확인
+        Pool poolSettings = pools.Find(p => p.tag == tag);
+        if (poolDictionary[tag].Count >= poolSettings.size)
+        {
+            Debug.Log($"Pool '{tag}' is full. Destroying object instead of returning to pool.");
+            Destroy(obj);  // 풀이 가득 찼으면 오브젝트 파괴
+            return;
+        }
+
+        // 오브젝트를 비활성화하고 풀에 반환
+        obj.SetActive(false);
+        poolDictionary[tag].Enqueue(obj);
     }
 }

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -1465,6 +1465,18 @@ MonoBehaviour:
   - tag: Female
     prefab: {fileID: 2756065083760134691, guid: 285ea8d5c61bc425f91b8750a5e47dc5, type: 3}
     size: 15
+  - tag: MaleMale
+    prefab: {fileID: 1892038888814880474, guid: 50f1636e6eb81f14b8e779d709acc2df, type: 3}
+    size: 15
+  - tag: MaleFemale
+    prefab: {fileID: 1892038888814880474, guid: e8556af67a023344c826e9aad311747d, type: 3}
+    size: 15
+  - tag: FemaleMale
+    prefab: {fileID: 1892038888814880474, guid: ffec0f956659d4848b6b97b37c20ae0e, type: 3}
+    size: 15
+  - tag: FemaleFemale
+    prefab: {fileID: 1892038888814880474, guid: c33488e7e4699014a8ecf667a9263fa1, type: 3}
+    size: 15
 --- !u!4 &1292296423
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -506,7 +506,7 @@ CircleCollider2D:
   m_CallbackLayers:
     serializedVersion: 2
     m_Bits: 4294967295
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_CompositeOperation: 0
   m_CompositeOrder: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -915,6 +915,9 @@ MonoBehaviour:
   rows: 5
   waveInterval: 1
   spawnCountPerWave: 4
+  groupNPCChance: 0.5
+  chasingNPCChance: 0.5
+  movingGroupNPCChance: 0.8
 --- !u!4 &777268009
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -913,11 +913,11 @@ MonoBehaviour:
   background: {fileID: 356500507}
   columns: 3
   rows: 5
-  waveInterval: 1
+  waveInterval: 5
   spawnCountPerWave: 4
   groupNPCChance: 0.5
   chasingNPCChance: 0.5
-  movingGroupNPCChance: 0.8
+  movingGroupNPCChance: 0.9
 --- !u!4 &777268009
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -910,10 +910,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gridStartPosition: {fileID: 455322031}
+  background: {fileID: 356500507}
   columns: 3
   rows: 5
-  zoneWidth: 0.5
-  zoneHeight: -1
   waveInterval: 1
   spawnCountPerWave: 4
 --- !u!4 &777268009

--- a/Assets/Sprites/joystick/joystick_btn.png.meta
+++ b/Assets/Sprites/joystick/joystick_btn.png.meta
@@ -160,7 +160,8 @@ TextureImporter:
     secondaryTextures: []
     spriteCustomMetadata:
       entries: []
-    nameFileIdTable: {}
+    nameFileIdTable:
+      joystick_btn_0: 3438052786177196309
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 


### PR DESCRIPTION
<!-- PR 제목은 "feat: 점프 기능 추가" 이런식으로 작성해주시면 됩니다 -->

## 🏷️ PR 타입
- [x] 기능 추가
- [ ] 기능 변경
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 리소스 변경
- [ ] 기타(의존성, 환경변수, 빌드관련 등)

## #️⃣ 관련 이슈 (선택)
<!-- 관련 이슈 번호를 적어주세요. 예: #123 -->

## 📝 작업 내용 요약
<!-- 이번 PR에서 작업한 내용을 간단하게 작성해주세요. (예: 버그 수정, 기능 추가 등) -->
1. 스폰 존이 너무 작은 버그 -> `zoneWidth`와 `zoneHeight`을 화면 크기에 맞춰 동적으로 초기화 되도록 변경했습니다.
2. NPC와 닿을 시 이벤트를 연결할 수 있습니다.
3. NPC가 `GameManager.currentScrollSpeed`에 의해 맵과 같이 움직입니다.
4. 갑자기 NPC가 사라지는 오류 -> `ObjectPooler.ReturnToPool()`을 만들어 해결
5. 단체 NPC는 `GroupNPCController`에 의해 동작합니다.
6. 수직이동형 NPC가 고정형이 있는 열에서 생성 되지 않습니다.
7. 생성 시 NPC가 겹치지 않도록 생성 구역의 크기를 조절하는 코드를 작성했습니다.
8. `transform` 대신 `Rigidbody2D`와 `FixedUpdate()`를 활용한 로직으로 변경했습니다. 

## 🗂️ 변경 사항 상세
<!-- 파일이름 적을 때에는 `파일이름`과 같이 감싸주시면 좋습니다 -->
- 코드 관련:
### 0️⃣ `ObjectPooler.cs`
- `SpawnFromPool()`: 풀에서 가져오려는데 풀이 비어있으면 새 프리팹을 `Instantiate()`하도록 수정
- `ReturnToPool()`:  풀에 반환하는데 풀이 이미 차있으면 `Destroy()`하도록 수정

### 1️⃣ `NPCSpawner.cs`
#### Public Fields
- `Instance`: `NPCSpawner`를 싱글톤으로 설정하여 다른 스크립트(NPCController)에서도 쉽게 접근
- `background`: **화면 크기**에 맞춰 생성 구역을 계산하기 위함
-`groupNPCChance`, `chasingNPCChance`, `movingGroupNPCChance`: NPC 유형별 생성 확률, 0에서 1 사이의 값
#### Private Fields
- `groupTags`: 새로운 단체 NPC 풀의 초기화, 생성, 반환을 위한 태그(`genderTags`와 역할이 비슷) 
- `zonePadding`: 생성 시 겹침 문제 방지 위해 생성 구역에 적용하는 간격
- `movingGroupsRestrictedColumns`: 고정형 NPC가 소환된 열을 기록하는 `List<float>`
#### Public Method
- `RemoveSpawnRestriction(float column)`
    - `movingGroupsRestrictedColumns`에서 주어진 열`column` 하나 삭제
    - NPCController에서 자신에게 알맞은 풀에 반환하기 위해 사용

#### Private Method
- `OnDrawGizmos()`: 테스트용 코드로, 플레이 모드의 Scene에서 NPC가 스폰하는 구역을 확인할 수 있음

#### 기본 로직
1. `groupNPCChance`확률로 **1인 NPC** vs **단체 NPC** 결정
2. **1인 NPC**일 경우, `chasingNPCChance`확률로 **고정형** vs **추적형** 결정
    a. **고정형**일 경우, 소환되는 열의 x좌표를 기록, NPC 초기화 
    b. **추적형**일 경우, 그냥 NPC 초기화
3. **단체 NPC**일 경우, `movingGroupNPCChance`확률로 **수직이동형** vs **고정형** 결정
    a. **수직이동형일 경우**, 그냥 NPC 초기화
    b. **고정형**일 경우, 소환되는 열의 x좌표를 기록, NPC 초기화

#### 기타 사항
- `Line 97`: `spawnPos` 로직 변경 - `zoneWidth`, `zoneHeight`과 `zonePadding`이용해 위치 랜덤 설정 범위를 동적으로 계산하여, NPC들이 서로 겹치지 않도록 범위 설정
 
### 2️⃣ `NPCController.cs`
#### Public Fields
- `poolType`: 알맞은 풀에 반환하기 위한 태그
- `onPlayerCollision`: Inspector에서 이벤트 연결 가능
- `columnSpawnedIn`: 고정형일 경우, 어떤 열에서 생성되었는지 저장 - 수직이동형 생성 금지를 위한 기록

#### Private Field
- `rb`: Rigidbody2D

#### Private Methods
- `PoolTag`: 현재 `poolType`을 `string`형으로 반환 - 풀로 반환할 때 필요
- `OnTriggerEnter2D`: 플레이어의 Collider를 감지하고, 물음표 표시 후 이벤트 발생

#### 기타 사항
- Rigidbody와 Fixed 적용
    - `Update()` -> `FixedUpdate()`
    - `Time.deltaTime` -> `Time.fixedDeltaTime`
    - `transform.Translate()` -> `rb.MovePosition()` 
- `OnBecameInvisible()` 수정
    - `NPCSpawner.Instance.RemoveSpawnRestriction()` 호출하여, 수직이동형 NPC가 이 NPC의 열에서 다시 소환될 수 있도록 열 기록 삭제
    - `ObjectPooler.Instance.ReturnToPool()` 호출하여 풀로 반환
- `RunFixedLogic()`: 맵 스크롤에 따라 알아서 움직이므로 코드 삭제
- `RunChaserLogic()`
    - `Random.insideUnitSphere.normalized`(Edit -> `insideUnitCircle`)를 이용해 랜덤 방향을 균등하게 설정
    - 로직이 활성화 되지 않았을 때, 고정형과 같이 코드 삭제

### 3️⃣ `GroupNPCController.cs`
- `NPCController.cs`와 구조가 거의 다 동일
- 다른 점
    - `behaviorType`: 단체 NPC는 행동 타입이 `Fixed`와 `Moving`
    - `poolType`: 네 개의 풀 타입(`MaleMale`, `MaleFemale`, `FemaleMale`, `FemaleFemale`) 
    - `animators`: Animator 컴포넌트가 자식 오브젝트에 두 개 있기에, 각각에 대해서 설정

- 프리팹/씬/에셋 관련: 
### 프리팹
- 단체 NPC
    - NPC_female_female
    - NPC_female_male
    - NPC_male_female
    - NPC_male_male
    - `GroupNPCController` 장착
    - `SpriteRenderer` 장착
    - `RigidBody2D` 장착
    - `BoxCollider2D` 장착, Collider 사이즈 조정

- 씬
    - ObjectPooler 게임 오브젝트
        - `ObjectPooler`컴포넌트의 `Pools`에 단체 NPC 정보 추가
    - NPCSpawner 게임 오브젝트
        - `NPCSpawner`컴포넌트의 `Background`에 Background 게임 오브젝트 할당
    - Player 게임 오브젝트
        - `CircleCollider2D`컴포넌트의 `IsTrigger`에 체크 ☑️


- 기타 리소스 관련: 

## 🧪 테스트 방법
<!-- 변경 사항이 잘 동작하는지 확인한 방법을 구체적으로 작성해주세요. (예: 플레이 모드에서 특정 버튼 클릭, 유닛 테스트 등) -->
- 대부분: 플레이 모드에서 오래 실행하여 직접 확인
- 이벤트: 로그를 찍는 스크립트를 부착한 프리팹을, NPC들 Inspector에서 할당 후, 플레이 모드에서 부딪혀 봄
- 스폰 구역 크기 조절: `OnDrawGizmos()`로 플레이 모드의 Scene에서 확인

## 🖼️ 스크린샷 (선택)
<!-- UI/그래픽 변경이 있다면 스크린샷을 첨부해주세요. -->
![asdfasdf-ezgif com-optimize](https://github.com/user-attachments/assets/c8d9daf8-ffdc-418e-ac32-980d74e010f2)


## 💬 리뷰어에게 요청 사항 (선택)
<!-- 리뷰 시 중점적으로 봐줬으면 하는 부분이나, 궁금한 점이 있다면 작성해주세요. -->
NPCSpawner 로직이 꽤 변경되었으니 중점적으로 봐 주시고 이해가 안 된다면 디스코드에서 많이 질문해주세요

## ✅ 체크리스트
- [x] 코드 및 에셋 변경 사항을 모두 확인했습니다.
- [x] 커밋 후 Pull(머지 충돌 방지)을 먼저 하고 Push를 했습니다.
- [x] 충돌 가능성이 있는 파일(씬, 프리팹 등)을 확인했습니다.
- [x] 테스트를 완료했습니다.
